### PR TITLE
fix behavior when multiple tags are selected

### DIFF
--- a/scratch.lua
+++ b/scratch.lua
@@ -18,12 +18,20 @@ local function turn_on(c)
     client.focus = c
 end
 
--- Turn off this scratch window client (remove current tag from window's tags)
+-- Turn off this scratch window client (remove current tags from window's tags)
 local function turn_off(c)
-    local current_tag = awful.tag.selected(c.screen)
-    local ctags = {}
-    for k,tag in pairs(c:tags()) do
-        if tag ~= current_tag then table.insert(ctags, tag) end
+    local sel_tags = awful.screen.focused().selected_tags
+    local ctags = c:tags()
+    for k, target in pairs(sel_tags) do
+        for i, v in pairs(ctags) do
+            if v == target then
+                index = i
+                break
+            end
+        end
+        if index then
+            ctags[index] = nil
+        end
     end
     c:tags(ctags)
 end


### PR DESCRIPTION
when multiple tags are selected, toggling the scratch off removes only the first one from its tags, so it still remains on the screen if it happened to be present in the other tags as well.

This patch makes it work as expected - all the selected tags are removed from the scratchpad's tags. To make it more consistent, maybe we should make the `turn_on` method to handle multiple tags as well?

BTW, I'm new to lua. How the hell is there no `table.find_by_value` or something? This loop stinks, but I copied the code from AwesomeWM's `client:toggle_tag(t)` so I assume this is the standard approach.